### PR TITLE
Jinju9513/issue5

### DIFF
--- a/lib/UI/pages/my_page/my_page.dart
+++ b/lib/UI/pages/my_page/my_page.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:recipea_app/UI/pages/my_page/widgets/icon_text_item.dart';
+import 'package:recipea_app/UI/pages/my_page/widgets/section_container.dart';
+import 'package:recipea_app/UI/pages/my_page/widgets/user_header.dart';
+
+class MyPage extends StatelessWidget {
+  const MyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 1,
+        title: const Text(
+          '마이컬리',
+          style: TextStyle(
+            color: Colors.black,
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        centerTitle: false,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout, color: Colors.black),
+            onPressed: () {
+              // TODO: 로그아웃 처리 로직
+              print('로그아웃 클릭됨');
+            },
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              UserHeader(),
+              _buildRecipeSection(),
+              _buildShoppingSection(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRecipeSection() {
+    return SectionContainer(
+      title: '레시피',
+      children: [
+        IconTextItem(label: '내가 본 레시피', icon: Icons.remove_red_eye, value: '3'),
+        IconTextItem(label: '스크랩', icon: Icons.bookmark_border, value: '0'),
+        IconTextItem(label: 'MY냉장고', icon: MdiIcons.fridge, value: '0'),
+        IconTextItem(label: '노트', icon: Icons.note_outlined, value: '0'),
+      ],
+    );
+  }
+
+  Widget _buildShoppingSection() {
+    return SectionContainer(
+      title: '쇼핑',
+      // subtitle: '적립금 0원',
+      children: const [
+        IconTextItem(
+          label: '내가 본 상품',
+          icon: Icons.remove_red_eye_outlined,
+          value: '0',
+        ),
+        IconTextItem(label: '구매내역', icon: Icons.credit_card, value: '0/0'),
+        IconTextItem(
+          label: '장바구니/찜',
+          icon: Icons.shopping_cart_outlined,
+          value: '0/0',
+        ),
+        IconTextItem(label: '쿠폰', icon: Icons.local_offer_outlined, value: '7'),
+      ],
+    );
+  }
+}

--- a/lib/UI/pages/my_page/widgets/icon_text_item.dart
+++ b/lib/UI/pages/my_page/widgets/icon_text_item.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class IconTextItem extends StatelessWidget {
+  final String label;
+  final IconData icon;
+  final String value;
+
+  const IconTextItem({
+    super.key,
+    required this.label,
+    required this.icon,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(icon, size: 28),
+        const SizedBox(height: 4),
+        Text(label, style: const TextStyle(fontSize: 12)),
+      ],
+    );
+  }
+}

--- a/lib/UI/pages/my_page/widgets/section_container.dart
+++ b/lib/UI/pages/my_page/widgets/section_container.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class SectionContainer extends StatelessWidget {
+  final String title;
+  // final String? subtitle;
+  final List<Widget> children;
+
+  const SectionContainer({
+    super.key,
+    required this.title,
+    // this.subtitle,
+    required this.children,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              // if (subtitle != null) ...[
+              //   const Spacer(),
+              //   Text(subtitle!, style: const TextStyle(color: Colors.grey)),
+              // ],
+            ],
+          ),
+          const SizedBox(height: 12),
+          GridView.count(
+            crossAxisCount: 4,
+            childAspectRatio: 1,
+            physics: const NeverScrollableScrollPhysics(),
+            shrinkWrap: true,
+            children: children,
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/UI/pages/my_page/widgets/user_header.dart
+++ b/lib/UI/pages/my_page/widgets/user_header.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class UserHeader extends StatelessWidget {
+  const UserHeader({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.blueGrey[100],
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        children: [
+          const CircleAvatar(radius: 30, backgroundColor: Colors.grey),
+          const SizedBox(width: 16),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: const [
+              Text('전진주', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            ],
+          ),
+          const Spacer(),
+          const Icon(Icons.settings),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  material_design_icons_flutter: ^7.0.7296
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### 🚀: 개요
-  MYPAGE UI 레이아웃 구현

### 🚀: 작업 내용
- MYPAGE  UI 레이아웃 구현
- 위젯 분리

### 📸: 실행 화면
![simulator_screenshot_2DF0EBAB-12FB-415A-BED2-7405D040074C](https://github.com/user-attachments/assets/784311d0-d1f1-4a3c-9539-6944fb62b474)

### 🚀: 조정 파일
- my_page.dart
- section_container.dart
- user_header.dart
- icon_text_item.dart
- pubsepec.yaml

### 개발 결과
- 마이 페이지 생성 완료
- 위젯 분리 및 컴포넌트 완료
