### PR TITLE
[Home] Home Page UI 틀 생성

### DIFF
--- a/lib/UI/pages/home/home_page.dart
+++ b/lib/UI/pages/home/home_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:recipea_app/UI/pages/home/widgets/home_banner.dart';
 import 'package:recipea_app/UI/pages/home/widgets/home_category.dart';
-import 'package:recipea_app/UI/pages/home/widgets/home_sale.dart';
+import 'package:recipea_app/UI/pages/home/widgets/home_popular.dart';
 import 'package:recipea_app/UI/pages/widgets/bottom_bar.dart';
 
 class HomePage extends StatelessWidget {
@@ -14,11 +14,19 @@ class HomePage extends StatelessWidget {
           children: [
             Text('Recipea'),
             Icon(Icons.notifications),
-            Icon(Icons.shopping_cart),
+            Icon(Icons.search),
           ],
         ),
       ),
-      body: ListView(children: [HomeBanner(), HomeCategory(), HomeSale()]),
+      body: ListView(
+        children: [
+          HomeBanner(),
+          SizedBox(height: 16),
+          HomeCategory(),
+          SizedBox(height: 16),
+          HomePopular(),
+        ],
+      ),
       bottomNavigationBar: BottomAppBar(child: BottomBar()),
     );
   }

--- a/lib/UI/pages/home/home_page.dart
+++ b/lib/UI/pages/home/home_page.dart
@@ -10,15 +10,29 @@ class HomePage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.purple,
-        title: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        title: Stack(
           children: [
-            Text('Recipea'),
-            Icon(Icons.notifications),
-            Icon(Icons.search),
+            Center(
+              child: Text(
+                'Recipea',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
+            ),
+
+            Positioned(
+              right: 0,
+              child: Row(
+                children: [
+                  Icon(Icons.notifications),
+                  SizedBox(width: 16),
+                  Icon(Icons.search),
+                ],
+              ),
+            ),
           ],
         ),
       ),
+
       body: ListView(
         children: [
           HomeBanner(),

--- a/lib/UI/pages/home/home_page.dart
+++ b/lib/UI/pages/home/home_page.dart
@@ -2,12 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:recipea_app/UI/pages/home/widgets/home_banner.dart';
 import 'package:recipea_app/UI/pages/home/widgets/home_category.dart';
 import 'package:recipea_app/UI/pages/home/widgets/home_sale.dart';
+import 'package:recipea_app/UI/pages/widgets/bottom_bar.dart';
 
 class HomePage extends StatelessWidget {
   @override
   Widget build(Object context) {
     return Scaffold(
       appBar: AppBar(
+        backgroundColor: Colors.purple,
         title: Row(
           children: [
             Text('Recipea'),
@@ -17,6 +19,7 @@ class HomePage extends StatelessWidget {
         ),
       ),
       body: ListView(children: [HomeBanner(), HomeCategory(), HomeSale()]),
+      bottomNavigationBar: BottomAppBar(child: BottomBar()),
     );
   }
 }

--- a/lib/UI/pages/home/home_page.dart
+++ b/lib/UI/pages/home/home_page.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:recipea_app/UI/pages/home/widgets/home_banner.dart';
+import 'package:recipea_app/UI/pages/home/widgets/home_category.dart';
+import 'package:recipea_app/UI/pages/home/widgets/home_sale.dart';
+
+class HomePage extends StatelessWidget {
+  @override
+  Widget build(Object context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Row(
+          children: [
+            Text('Recipea'),
+            Icon(Icons.notifications),
+            Icon(Icons.shopping_cart),
+          ],
+        ),
+      ),
+      body: ListView(children: [HomeBanner(), HomeCategory(), HomeSale()]),
+    );
+  }
+}

--- a/lib/UI/pages/home/home_page.dart
+++ b/lib/UI/pages/home/home_page.dart
@@ -11,6 +11,7 @@ class HomePage extends StatelessWidget {
       appBar: AppBar(
         backgroundColor: Colors.purple,
         title: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text('Recipea'),
             Icon(Icons.notifications),

--- a/lib/UI/pages/home/widgets/home_banner.dart
+++ b/lib/UI/pages/home/widgets/home_banner.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+class HomeBanner extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold();
+  }
+}

--- a/lib/UI/pages/home/widgets/home_banner.dart
+++ b/lib/UI/pages/home/widgets/home_banner.dart
@@ -3,6 +3,18 @@ import 'package:flutter/material.dart';
 class HomeBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Text('banner');
+    return SizedBox(
+      height: 500,
+      child: PageView.builder(
+        itemCount: 10,
+        itemBuilder: (context, index) {
+          return Container(
+            height: 120,
+            decoration: BoxDecoration(color: Colors.red),
+            child: Center(child: Text('예시')),
+          );
+        },
+      ),
+    );
   }
 }

--- a/lib/UI/pages/home/widgets/home_banner.dart
+++ b/lib/UI/pages/home/widgets/home_banner.dart
@@ -4,7 +4,7 @@ class HomeBanner extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: 500,
+      height: 300,
       child: PageView.builder(
         itemCount: 10,
         itemBuilder: (context, index) {

--- a/lib/UI/pages/home/widgets/home_category.dart
+++ b/lib/UI/pages/home/widgets/home_category.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+class HomeCategory extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold();
+  }
+}

--- a/lib/UI/pages/home/widgets/home_category.dart
+++ b/lib/UI/pages/home/widgets/home_category.dart
@@ -8,8 +8,15 @@ class HomeCategory extends StatelessWidget {
       child: Wrap(
         spacing: 12,
         runSpacing: 12,
-        children: List.generate(30, (index) {
-          return Container(width: 100, height: 100, color: Colors.amber);
+        children: List.generate(12, (index) {
+          return Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(10),
+              color: Colors.amber,
+            ),
+            width: 55,
+            height: 55,
+          );
         }),
       ),
     );

--- a/lib/UI/pages/home/widgets/home_category.dart
+++ b/lib/UI/pages/home/widgets/home_category.dart
@@ -3,6 +3,6 @@ import 'package:flutter/material.dart';
 class HomeCategory extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Scaffold();
+    return Text('category');
   }
 }

--- a/lib/UI/pages/home/widgets/home_category.dart
+++ b/lib/UI/pages/home/widgets/home_category.dart
@@ -3,17 +3,14 @@ import 'package:flutter/material.dart';
 class HomeCategory extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      height: 100,
-      child: ListView.builder(
-        scrollDirection: Axis.horizontal,
-        itemCount: 20,
-        itemBuilder: (context, index) {
-          return Container(
-            decoration: BoxDecoration(color: Colors.blue),
-            child: Center(child: Text('예시 카테고리')),
-          );
-        },
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Wrap(
+        spacing: 12,
+        runSpacing: 12,
+        children: List.generate(30, (index) {
+          return Container(width: 100, height: 100, color: Colors.amber);
+        }),
       ),
     );
   }

--- a/lib/UI/pages/home/widgets/home_category.dart
+++ b/lib/UI/pages/home/widgets/home_category.dart
@@ -3,6 +3,18 @@ import 'package:flutter/material.dart';
 class HomeCategory extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Text('category');
+    return SizedBox(
+      height: 100,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemCount: 20,
+        itemBuilder: (context, index) {
+          return Container(
+            decoration: BoxDecoration(color: Colors.blue),
+            child: Center(child: Text('예시 카테고리')),
+          );
+        },
+      ),
+    );
   }
 }

--- a/lib/UI/pages/home/widgets/home_popular.dart
+++ b/lib/UI/pages/home/widgets/home_popular.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class HomePopular extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 200,
+      child: Column(
+        children: [
+          Text(
+            '가장 인기있는 레시피',
+            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+          ),
+          SizedBox(height: 16),
+          Expanded(
+            child: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              itemCount: 10,
+              itemBuilder: (context, index) {
+                return Container(
+                  decoration: BoxDecoration(color: Colors.green),
+                  child: Text('예시 인기있는'),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/UI/pages/home/widgets/home_popular.dart
+++ b/lib/UI/pages/home/widgets/home_popular.dart
@@ -17,9 +17,17 @@ class HomePopular extends StatelessWidget {
               scrollDirection: Axis.horizontal,
               itemCount: 10,
               itemBuilder: (context, index) {
-                return Container(
-                  decoration: BoxDecoration(color: Colors.green),
-                  child: Text('예시 인기있는'),
+                return Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: AspectRatio(
+                    aspectRatio: 1,
+                    child: Container(
+                      width: 200,
+                      height: 200,
+                      decoration: BoxDecoration(color: Colors.green),
+                      child: Text('예시 인기있는'),
+                    ),
+                  ),
                 );
               },
             ),

--- a/lib/UI/pages/home/widgets/home_sale.dart
+++ b/lib/UI/pages/home/widgets/home_sale.dart
@@ -1,8 +1,0 @@
-import 'package:flutter/material.dart';
-
-class HomeSale extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Text('sale');
-  }
-}

--- a/lib/UI/pages/home/widgets/home_sale.dart
+++ b/lib/UI/pages/home/widgets/home_sale.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+class HomeSale extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold();
+  }
+}

--- a/lib/UI/pages/home/widgets/home_sale.dart
+++ b/lib/UI/pages/home/widgets/home_sale.dart
@@ -3,6 +3,6 @@ import 'package:flutter/material.dart';
 class HomeSale extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Scaffold();
+    return Text('sale');
   }
 }

--- a/lib/UI/pages/widgets/bottom_bar.dart
+++ b/lib/UI/pages/widgets/bottom_bar.dart
@@ -3,6 +3,19 @@ import 'package:flutter/material.dart';
 class BottomBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Text('bottombar');
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceAround,
+      children: [
+        _buildNavItem(Icons.home, '홈'),
+        _buildNavItem(Icons.forum, '라운지'),
+        _buildNavItem(Icons.category, '카테고리'),
+        _buildNavItem(Icons.search, '검색'),
+        _buildNavItem(Icons.person, '마이페이지'),
+      ],
+    );
+  }
+
+  Widget _buildNavItem(IconData icon, String label) {
+    return Column(children: [Icon(icon), SizedBox(height: 10), Text(label)]);
   }
 }

--- a/lib/UI/pages/widgets/bottom_bar.dart
+++ b/lib/UI/pages/widgets/bottom_bar.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
-class HomeBanner extends StatelessWidget {
+class BottomBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Text('banner');
+    return Text('bottombar');
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:recipea_app/UI/pages/home/home_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -7,116 +8,8 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
-    );
+    return MaterialApp(home: HomePage());
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -123,6 +123,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.11.1"
+  material_design_icons_flutter:
+    dependency: "direct main"
+    description:
+      name: material_design_icons_flutter
+      sha256: "6f986b7a51f3ad4c00e33c5c84e8de1bdd140489bbcdc8b66fc1283dad4dea5a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.7296"
   meta:
     dependency: transitive
     description:
@@ -209,5 +217,5 @@ packages:
     source: hosted
     version: "14.3.1"
 sdks:
-  dart: ">=3.7.2 <4.0.0"
+  dart: "3.7.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.7.2
+  sdk: 3.7.0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
### 🚀: 개요
- [Home] Home Page UI 틀 생성

### 🚀: 작업 내용
- Home Page UI 틀 생성
- 위젯 분리
- 바텀바 생성

### 📸: 실행 화면
### 📸: 실행 화면
![1111111](https://github.com/user-attachments/assets/f2d3e184-ec84-439b-a93d-d9096122ed99)


### 🚀: 조정 파일
- home_page.dart
- home_banner.dart
- home_category.dart
- home_popular.dart
- bottom_bar.dart

### 개발 결과
- Home Page UI 틀 생성
- 위젯 분리
- 각 위젯 UI 조정
- 바텀바 생성
- 바텀바 아이템 위젯 생성
- 바텀바 조정
